### PR TITLE
Issue36 - get subject by external record id API

### DIFF
--- a/ehb_service/apps/api/resources/subject.py
+++ b/ehb_service/apps/api/resources/subject.py
@@ -50,14 +50,12 @@ class SubjectResource(Resource):
         if external_sys and external_id:
             try:
                 ex_record = ExternalRecord.objects.filter(external_system=external_sys).filter(record_id=external_id)
+                if ex_record.__len__() != 1:
+                    log.error("External Record id {0} does not exist".format(ex_record))
+                    return HttpResponse(status=codes.not_found)
                 for s in ex_record:
                     sub = s.subject.id
                 s = Subject.objects.get(pk=sub)
-                if subs.__len__() == 1:
-                    s = subs[0]
-                else:
-                    log.error("Subject not found with external record id: {0}".format(external_id))
-                    return HttpResponse(status=codes.not_found)
 
             except Organization.DoesNotExist:
                 log.error("Subject not found. Given External Record does not exist")

--- a/ehb_service/apps/api/resources/subject.py
+++ b/ehb_service/apps/api/resources/subject.py
@@ -32,7 +32,7 @@ class SubjectResource(Resource):
                 log.error("Subject[{0}] not found".format(pk))
                 return HttpResponse(status=codes.not_found)
 
-        # search for subjects based on their orginization and
+        # search for subjects based on their orginization and subj ID
         if orgpk and org_sub_id:
             try:
                 org = Organization.objects.get(pk=orgpk)
@@ -53,6 +53,11 @@ class SubjectResource(Resource):
                 for s in ex_record:
                     sub = s.subject.id
                 s = Subject.objects.get(pk=sub)
+                if subs.__len__() == 1:
+                    s = subs[0]
+                else:
+                    log.error("Subject not found with external record id: {0}".format(external_id))
+                    return HttpResponse(status=codes.not_found)
 
             except Organization.DoesNotExist:
                 log.error("Subject not found. Given External Record does not exist")

--- a/ehb_service/apps/api/resources/subject.py
+++ b/ehb_service/apps/api/resources/subject.py
@@ -49,14 +49,7 @@ class SubjectResource(Resource):
         # search for subjects based on an external record id
         if external_sys and external_id:
             try:
-                ex_record = ExternalRecord.objects.filter(external_system=external_sys).filter(record_id=external_id)
-                if ex_record.__len__() != 1:
-                    log.error("External Record id {0} does not exist".format(ex_record))
-                    return HttpResponse(status=codes.not_found)
-                for s in ex_record:
-                    sub = s.subject.id
-                s = Subject.objects.get(pk=sub)
-
+                s = self.search_sub_by_external_record_id(external_sys, external_id)
             except Organization.DoesNotExist:
                 log.error("Subject not found. Given External Record does not exist")
                 return HttpResponse(status=codes.not_found)
@@ -135,3 +128,13 @@ class SubjectResource(Resource):
                 )
 
         return json.dumps(response)
+
+    def search_sub_by_external_record_id(self, external_sys, external_id):
+        ex_record = ExternalRecord.objects.filter(external_system=external_sys).filter(record_id=external_id)
+        if ex_record.__len__() != 1:
+            log.error("External Record id {0} does not exist".format(ex_record))
+            return HttpResponse(status=codes.not_found)
+        for s in ex_record:
+            sub = s.subject.id
+        s = Subject.objects.get(pk=sub)
+        return s

--- a/ehb_service/apps/api/urls.py
+++ b/ehb_service/apps/api/urls.py
@@ -5,6 +5,7 @@ subject_patterns = patterns(
     url(r'^$', 'SubjectResource'),
     url(r'^id/(?P<pk>\d+)/$', 'SubjectResource'),
     url(r'^organization/(?P<org_pk>\d+)/osid/(?P<osid>\w+)/$', 'SubjectResource'),
+    url(r'^externalrecsys/(?P<externalrecsys>\d+)/erid/(?P<erid>.*)/$', 'SubjectResource'),
 )
 
 organization_patterns = patterns(


### PR DESCRIPTION
Create an API call where user inputs external record system and external record ID and receive subjects information that is linked to external record id.

an example call will be:
http://127.0.0.1:8000/api/subject/externalrecsys/2/erid/1234abc/